### PR TITLE
text(legacy doc): have root and all other paths those headers

### DIFF
--- a/nextjs/docs/advanced-features/security-headers.md
+++ b/nextjs/docs/advanced-features/security-headers.md
@@ -18,7 +18,7 @@ module.exports = {
     return [
       {
         // Apply these headers to all routes in your application.
-        source: '/(.*)',
+        source: '/:path*',
         headers: securityHeaders,
       },
     ]


### PR DESCRIPTION
- `/(.*)` would result in `/` (root) not having the headers
- now a request to root will also have the headers included in the response
- works with blitz 0.45.5
- not sure, though, if this is still of any use here